### PR TITLE
refactor(team-members): write the extra_chill_team role directly (closes #8)

### DIFF
--- a/inc/core/abilities/handlers/team-members.php
+++ b/inc/core/abilities/handlers/team-members.php
@@ -2,44 +2,145 @@
 /**
  * Team member ability handlers.
  *
+ * Writes the extra_chill_team WP role directly via the primitives
+ * exposed by extrachill-users. The role IS the source of truth —
+ * there is no auxiliary meta layer, no derivation step, no auto/
+ * manual distinction.
+ *
+ * This file replaces the earlier circular call chain
+ * (sync-team-members → extrachill_api_sync_team_members →
+ *  wp_get_ability(sync-team-members)→execute → back here)
+ * that resolved Extra-Chill/extrachill-admin-tools#8 by construction
+ * — both abilities now have real implementations.
+ *
  * @package ExtraChillAdminTools
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Sync team members.
+ * Sync team role to every site for every current team member.
  *
- * @param array $input Input parameters (unused).
+ * Idempotent. Use after adding a new subsite to the network to ensure
+ * existing team members get the role assignment on the new site, or
+ * after any manual role state changes that should be propagated.
+ *
+ * The implementation walks every user who already has the
+ * extra_chill_team role anywhere in the network and re-grants the
+ * role on every site. Already-assigned sites are no-ops via
+ * ec_users_grant_team_role's internal duplicate check.
+ *
+ * @param array $input Input parameters (unused; ability signature requirement).
  * @return array|WP_Error
  */
+// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- ability execute_callback signature requires the $input parameter.
 function extrachill_admin_tools_ability_sync_team( $input ) {
-	if ( ! function_exists( 'extrachill_api_sync_team_members' ) ) {
-		return new WP_Error( 'dependency_missing', 'extrachill-api plugin is required.' );
+	if ( ! function_exists( 'ec_users_grant_team_role' ) ) {
+		return new WP_Error( 'dependency_missing', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$request  = new WP_REST_Request( 'POST', '/extrachill/v1/admin/team-members/sync' );
-	$response = extrachill_api_sync_team_members( $request );
+	$team_user_ids = extrachill_admin_tools_get_current_team_user_ids();
 
-	return extrachill_admin_tools_ability_rest_result( $response );
+	$sites_processed = 0;
+	foreach ( $team_user_ids as $user_id ) {
+		$added            = ec_users_grant_team_role( $user_id );
+		$sites_processed += count( $added );
+	}
+
+	return array(
+		'total_team_users' => count( $team_user_ids ),
+		'sites_processed'  => $sites_processed,
+	);
 }
 
 /**
- * Manage a single team member.
+ * Grant or revoke the team role for a single user.
  *
  * @param array $input Input with user_id and action.
+ *                     - user_id: int
+ *                     - action: 'force_add' or 'force_remove'
  * @return array|WP_Error
  */
 function extrachill_admin_tools_ability_manage_team_member( $input ) {
-	if ( ! function_exists( 'extrachill_api_manage_team_member' ) ) {
-		return new WP_Error( 'dependency_missing', 'extrachill-api plugin is required.' );
+	if ( ! function_exists( 'ec_users_grant_team_role' ) || ! function_exists( 'ec_users_revoke_team_role' ) ) {
+		return new WP_Error( 'dependency_missing', 'extrachill-users plugin is required.', array( 'status' => 500 ) );
 	}
 
-	$request = new WP_REST_Request( 'PUT', '/extrachill/v1/admin/team-members/' . $input['user_id'] );
-	$request->set_param( 'user_id', $input['user_id'] );
-	$request->set_param( 'action', $input['action'] );
+	$user_id = isset( $input['user_id'] ) ? (int) $input['user_id'] : 0;
+	$action  = isset( $input['action'] ) ? (string) $input['action'] : '';
 
-	$response = extrachill_api_manage_team_member( $request );
+	if ( $user_id <= 0 ) {
+		return new WP_Error( 'invalid_user_id', 'A positive user_id is required.', array( 'status' => 400 ) );
+	}
 
-	return extrachill_admin_tools_ability_rest_result( $response );
+	if ( ! get_user_by( 'id', $user_id ) ) {
+		return new WP_Error( 'user_not_found', sprintf( 'User %d not found.', $user_id ), array( 'status' => 404 ) );
+	}
+
+	switch ( $action ) {
+		case 'force_add':
+			$sites = ec_users_grant_team_role( $user_id );
+			return array(
+				'message'        => sprintf( 'Team role granted on %d site(s).', count( $sites ) ),
+				'user_id'        => $user_id,
+				'is_team_member' => true,
+				'sites_added'    => $sites,
+			);
+
+		case 'force_remove':
+			$sites = ec_users_revoke_team_role( $user_id );
+			return array(
+				'message'        => sprintf( 'Team role revoked on %d site(s).', count( $sites ) ),
+				'user_id'        => $user_id,
+				'is_team_member' => false,
+				'sites_removed'  => $sites,
+			);
+
+		default:
+			return new WP_Error(
+				'invalid_action',
+				sprintf( 'Unknown action: %s. Expected force_add or force_remove.', $action ),
+				array( 'status' => 400 )
+			);
+	}
+}
+
+/**
+ * Resolve the set of user IDs currently holding the extra_chill_team
+ * role on ANY site in the network.
+ *
+ * Used by the sync ability to find users whose role assignments may
+ * be out of sync (e.g. after a new subsite is added).
+ *
+ * @return int[]
+ */
+function extrachill_admin_tools_get_current_team_user_ids() {
+	global $wpdb;
+
+	$ids = array();
+
+	if ( function_exists( 'ec_users_get_network_site_ids' ) ) {
+		$site_ids = ec_users_get_network_site_ids();
+	} else {
+		$site_ids = array_map( 'intval', get_sites( array( 'fields' => 'ids' ) ) );
+	}
+
+	foreach ( $site_ids as $blog_id ) {
+		$blog_id  = (int) $blog_id;
+		$caps_key = $wpdb->get_blog_prefix( $blog_id ) . 'capabilities';
+
+		$user_ids = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $caps_key sanitized by $wpdb->get_blog_prefix().
+			$wpdb->prepare(
+				"SELECT user_id FROM {$wpdb->usermeta} WHERE meta_key = %s AND meta_value LIKE %s",
+				$caps_key,
+				'%' . $wpdb->esc_like( 'extra_chill_team' ) . '%'
+			)
+		);
+
+		foreach ( (array) $user_ids as $id ) {
+			$ids[ (int) $id ] = true;
+		}
+	}
+
+	return array_map( 'intval', array_keys( $ids ) );
 }

--- a/inc/core/abilities/registry.php
+++ b/inc/core/abilities/registry.php
@@ -112,7 +112,7 @@ function extrachill_admin_tools_register_abilities() {
 		'extrachill/manage-team-member',
 		array(
 			'label'               => __( 'Manage Team Member', 'extrachill-admin-tools' ),
-			'description'         => __( 'Force add, force remove, or reset a user\'s team member status.', 'extrachill-admin-tools' ),
+			'description'         => __( 'Grant or revoke the extra_chill_team WP role for a user, network-wide.', 'extrachill-admin-tools' ),
 			'category'            => 'extrachill-admin-tools',
 			'input_schema'        => array(
 				'type'       => 'object',
@@ -123,8 +123,8 @@ function extrachill_admin_tools_register_abilities() {
 					),
 					'action'  => array(
 						'type'        => 'string',
-						'description' => __( 'Action to take.', 'extrachill-admin-tools' ),
-						'enum'        => array( 'force_add', 'force_remove', 'reset_auto' ),
+						'description' => __( 'Action to take: force_add to grant the role, force_remove to revoke it.', 'extrachill-admin-tools' ),
+						'enum'        => array( 'force_add', 'force_remove' ),
 					),
 				),
 				'required'   => array( 'user_id', 'action' ),

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -123,7 +123,9 @@ const adminToolsApi = {
 			target_sites: targetSites,
 		} ),
 
-	// ── Team Member Management (migrated → abilities) ───────────────────
+	// ── Team Role Management ────────────────────────────────────────────
+	// The extra_chill_team WP role is the source of truth; these
+	// endpoints grant/revoke it network-wide.
 	// TODO: M8 follow-up — register ability for listing team members.
 	//       REST route: extrachill/v1/admin/team-members
 	getTeamMembers: ( search, page ) =>

--- a/src/tools/TeamMemberManagement.jsx
+++ b/src/tools/TeamMemberManagement.jsx
@@ -81,11 +81,6 @@ export default function TeamMemberManagement() {
 			),
 		},
 		{
-			key: 'source',
-			label: 'Source',
-			render: ( value ) => <span className="ec-source">{ value }</span>,
-		},
-		{
 			key: 'actions',
 			label: 'Actions',
 			render: ( _, row ) => (
@@ -93,9 +88,8 @@ export default function TeamMemberManagement() {
 					value=""
 					options={ [
 						{ label: '-- Select Action --', value: '' },
-						{ label: 'Force Add', value: 'force_add' },
-						{ label: 'Force Remove', value: 'force_remove' },
-						{ label: 'Reset to Auto', value: 'reset_auto' },
+						{ label: 'Grant Team Role', value: 'force_add' },
+						{ label: 'Revoke Team Role', value: 'force_remove' },
 					] }
 					onChange={ ( action ) => {
 						if ( action ) {
@@ -112,16 +106,21 @@ export default function TeamMemberManagement() {
 		<div className="ec-tool ec-tool--team-management">
 			<div className="ec-tool__description">
 				<p>
-					Sync team members from the main site (extrachill.com) and manage
-					manual overrides for fired staff or community moderators.
+					Grant or revoke the <code>extra_chill_team</code> WordPress
+					role network-wide. The role is the source of truth for team
+					membership — granting it gives the user real WP capabilities
+					(upload_files, edit_posts, access_studio, etc.) on every
+					subsite in the Extra Chill network.
 				</p>
 			</div>
 
 			<div className="ec-tool__section">
-				<h3>Sync Team Members</h3>
+				<h3>Re-sync Team Role Across Network</h3>
 				<p>
-					Automatically set team member status for all users with
-					extrachill.com accounts. Manual overrides will be preserved.
+					Re-grants the team role on every subsite for every current
+					team member. Useful after adding a new subsite to the
+					network so existing team members get the role assignment
+					on the new site. Idempotent.
 				</p>
 				<Button
 					variant="primary"
@@ -133,7 +132,7 @@ export default function TeamMemberManagement() {
 							<Spinner /> Syncing...
 						</>
 					) : (
-						'Sync Team Members from Main Site'
+						'Re-sync Team Role Across Network'
 					) }
 				</Button>
 				{ syncReport && (


### PR DESCRIPTION
Companion to [Extra-Chill/extrachill-users#48](https://github.com/Extra-Chill/extrachill-users/pull/48).

Closes #8.

## Context

extrachill-users#48 retires the \`extrachill_team\` / \`extrachill_team_manual_override\` user_meta and makes the \`extra_chill_team\` WP role the sole source of truth for team membership. This PR rewrites the two team-management abilities (\`extrachill/sync-team-members\` and \`extrachill/manage-team-member\`) to write the role directly via the new primitives exposed in extrachill-users.

## Why this closes #8

The previous handlers had a circular call chain with no terminal meta writer:

\`\`\`
extrachill_admin_tools_ability_sync_team
    → extrachill_api_sync_team_members (in extrachill-api)
        → wp_get_ability( 'extrachill/sync-team-members' )->execute
            → back to extrachill_admin_tools_ability_sync_team
\`\`\`

Both functions deferred to each other and nothing actually wrote \`extrachill_team\` meta anywhere. The team-management UI was broken; people set the meta by hand. After this PR, both abilities have real, terminal implementations — they call \`ec_users_grant_team_role\` / \`ec_users_revoke_team_role\` from extrachill-users, which write the role assignment directly to every site in the network. The chain is gone by construction.

## Changes

### Backend

- **\`inc/core/abilities/handlers/team-members.php\`** — full rewrite:
  - \`extrachill_admin_tools_ability_sync_team\` — walks every user currently holding the team role anywhere in the network, re-grants on every site. Idempotent. Useful after a new subsite is added.
  - \`extrachill_admin_tools_ability_manage_team_member\` — \`force_add\` grants the role network-wide via \`ec_users_grant_team_role\`. \`force_remove\` revokes via \`ec_users_revoke_team_role\`. The \`reset_auto\` action is gone (no auto-derivation step exists anymore).
  - \`extrachill_admin_tools_get_current_team_user_ids\` — helper that finds team-role holders via the per-blog \`{prefix}_capabilities\` usermeta.

- **\`inc/core/abilities/registry.php\`** — drop \`reset_auto\` from the \`manage-team-member\` action enum. Updated ability descriptions.

### Frontend

- **\`src/tools/TeamMemberManagement.jsx\`** — drop the 'Source' column (no auto/manual distinction), drop the 'Reset to Auto' option, relabel buttons to "Grant Team Role" / "Revoke Team Role" / "Re-sync Team Role Across Network", update descriptive prose to reflect that the role IS the state.

- **\`src/api/client.js\`** — comment updates only; function names stay the same for caller compatibility.

The \`build/\` directory is gitignored — homeboy rebuilds the JS bundle at release time from the JSX source changes.

## Coordinated merge order

1. **extrachill-users#48** first (ships the role + migration + grant/revoke primitives)
2. **This PR** (rewrites handlers to call the new primitives)
3. **[extrachill-api companion PR](https://github.com/Extra-Chill/extrachill-api/pulls)** (reads role state for GET responses)

This PR depends on extrachill-users#48 being deployed first — without \`ec_users_grant_team_role\` available, the new handlers return a \`dependency_missing\` error. Safe to merge here but coordinate the deploy.

Refs Extra-Chill/extrachill-users#45