### PR TITLE
chore: bump @extrachill/components to ^0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@wordpress/scripts": "^30.15.0"
   },
   "dependencies": {
-    "@extrachill/components": "^0.4.33",
+    "@extrachill/components": "^0.5.2",
     "@wordpress/api-fetch": "^7.0.0",
     "@wordpress/components": "^28.0.0",
     "@wordpress/element": "^6.0.0",


### PR DESCRIPTION
## Summary

Bumps `@extrachill/components` from `^0.4.33` → `^0.5.2` in extrachill-admin-tools.

## What changed

- **Dependency bump** in `package.json`: `@extrachill/components` `^0.4.33` → `^0.5.2`
- Rebuilt JS/CSS assets via `npm run build` (`wp-scripts build`) — build succeeded with **no errors**.

> Note: `build/` and `package-lock.json` are gitignored in this repo, so the only committed change is `package.json`. The build was run to verify the new component code/styles compile cleanly (confirmed: webpack pulls in `@extrachill/components/styles/components.scss` and compiles successfully).

## Behavior changes riding along (smoke-test these surfaces)

`@extrachill/components@0.5.2` ships three behavior changes the reviewer should verify in the admin tools UI:

1. **BlockShellInner centering fix** — `margin-inline:auto` for narrow/wide layouts. Check that block shells center correctly in both narrow and wide widths.
2. **SearchBox canonical button classes** — verify SearchBox-driven surfaces (e.g. `UserSearch`, `SearchBox`) render and style their buttons correctly.
3. **InlineStatus / Badge dark-mode token parity** — check `InlineStatus` and `Badge` rendering in dark mode for correct token usage.

## Build confirmation

```
webpack 5.107.2 compiled successfully
asset admin-tools.js 28.4 KiB [minimized]
asset admin-tools.css 17.6 KiB
```

## Lint

`homeboy lint extrachill-admin-tools` reports the **same 55 findings (50 eslint + 5 phpstan) on both `main` and this branch** — this dependency bump introduces **zero new lint findings**. Pre-existing debt (e.g. `Endroid\QrCode` phpstan class-not-found, eslint findings in untouched `src/` files) is left as-is.