### PR TITLE
build: pin ajv ^8 to fix wp-scripts webpack build on Node 25

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "author": "Chris Huber <hello@chubes.net>",
   "license": "GPL-2.0+",
   "devDependencies": {
-    "@wordpress/scripts": "^30.15.0"
+    "@wordpress/scripts": "^30.15.0",
+    "ajv": "^8.20.0"
   },
   "dependencies": {
     "@extrachill/components": "^0.5.2",


### PR DESCRIPTION
## Summary

On the live extrachill.com VPS (Node 25), the `@wordpress/scripts` webpack build for this plugin silently failed. npm hoists **ajv v6.15.0** to top-level `node_modules/ajv`, but `ajv-keywords@5.x` (pulled in via `schema-utils` → `copy-webpack-plugin` in `@wordpress/scripts`) requires **ajv v8** and imports `ajv/dist/compile/codegen` — a path that does not exist in ajv v6.

The universal build script downgrades the resulting error to a non-fatal **warning** and ships a **PHP-only artifact with no JS/CSS**, silently stripping the plugin's blocks.

## Reproduced error

```
[webpack-cli] Error: Cannot find module 'ajv/dist/compile/codegen'
```

Before the fix, `grep -m1 '"version"' node_modules/ajv/package.json` showed `6.15.0` at top level.

## Fix

Added `"ajv": "^8.20.0"` to `devDependencies` in `package.json`, forcing the correct ajv version to the top level.

After the fix:
- `node -e "require.resolve('ajv/dist/compile/codegen')"` resolves
- top-level ajv is now `8.20.0`
- `npm run build` prints `webpack 5.107.2 compiled successfully` and emits `admin-tools.js`, `admin-tools.css`, `admin-tools-rtl.css`, and `admin-tools.asset.php`

## Files changed

- `package.json` — added `ajv: ^8.20.0` to `devDependencies`

(`package-lock.json` is not tracked in this repo, so it is not included.)

## Context

Same root cause and fix already applied to **extrachill-community (v1.9.3)** and verified on **extrachill-users**.

Part of Extra-Chill/extrachill-community#126