### PR TITLE
fix: guard ability category registration against double-fire _doing_it_wrong notice

### DIFF
--- a/inc/core/abilities/category.php
+++ b/inc/core/abilities/category.php
@@ -11,6 +11,14 @@ defined( 'ABSPATH' ) || exit;
  * Register admin tools ability category.
  */
 function extrachill_admin_tools_register_category() {
+	if ( ! function_exists( 'wp_register_ability_category' ) ) {
+		return;
+	}
+
+	if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( 'extrachill-admin-tools' ) ) {
+		return;
+	}
+
 	wp_register_ability_category(
 		'extrachill-admin-tools',
 		array(


### PR DESCRIPTION
## The notice

```
PHP Notice: Function WP_Ability_Categories_Registry::register was called incorrectly.
Ability category "extrachill-admin-tools" is already registered.
in /var/www/extrachill.com/wp-includes/functions.php on line 6170
```

## Root cause

On this multisite, WordPress core's `wp_abilities_api_categories_init` action fires more than once per request. This plugin's callback called `wp_register_ability_category( 'extrachill-admin-tools', ... )` unconditionally, so the second hook fire re-registered an already-registered category and tripped core's `_doing_it_wrong` notice.

## The fix

Guard the registration with core's idempotency check `wp_has_ability_category()` so a repeat fire is a clean no-op. Also retains/adds the `function_exists()` guard for both the register and has helpers (they ship with the same core API). Slug, label, description, and hook are unchanged — only the idempotency guard was added.