### PR TITLE
chore(deps): bump @extrachill/components to ^0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ajv": "^8.20.0"
   },
   "dependencies": {
-    "@extrachill/components": "^0.5.2",
+    "@extrachill/components": "^0.8.0",
     "@wordpress/api-fetch": "^7.0.0",
     "@wordpress/components": "^28.0.0",
     "@wordpress/element": "^6.0.0",


### PR DESCRIPTION
## Summary

Bumps `@extrachill/components` from `^0.5.2` → `^0.8.0` in extrachill-admin-tools and rebuilds the plugin. Dependency-only change; no source edits.

- **Installed version:** `@extrachill/components@0.8.0` (confirmed in `node_modules/@extrachill/components/package.json`).
- **Build:** `npm run build` (wp-scripts) compiled successfully — `admin-tools.js` (28.4 KiB), `admin-tools.css`, RTL variant, and `admin-tools.asset.php` all emitted.
- **Tracked change:** only `package.json`. `package-lock.json` and `build/` are gitignored in this repo (build artifacts are produced at deploy time), so nothing else is committed — matches repo convention.

## On the tab-broadcast behavior (important reviewer note)

The motivating context for this bump was that 0.8.0's **`ResponsiveTabs`** broadcasts the active tab to the client-context registry (`window.ecClientContextRegistry`) by default via `useTabClientContext`, so Roadie/agents can see which tab the user is on.

**However, extrachill-admin-tools uses the plain `Tabs` export, not `ResponsiveTabs`:**
- `src/components/ToolTabs.jsx` imports `{ Tabs }` from `@extrachill/components`.
- In 0.8.0, only `ResponsiveTabs.js` imports `useTabClientContext` (with `broadcastTabContext = true` default). `Tabs.js` does **not** use the client-context hook.

As a result:
- **`ecClientContextRegistry` does NOT appear in the built bundle** (`grep -c ecClientContextRegistry build/admin-tools.js` → 0). This is expected and correct given that `Tabs` (not `ResponsiveTabs`) is what's bundled here.
- This dep bump alone does **not** activate tab broadcasting in admin-tools. Enabling it would require switching `ToolTabs.jsx` from `Tabs` → `ResponsiveTabs`, which is a source change and **out of scope** for this PR.

The bump is still correct and safe (gets admin-tools onto the current components major and keeps it in sync with the rest of the platform), but flagging the broadcast premise so it's not assumed to be live. Happy to follow up with a `Tabs → ResponsiveTabs` migration PR if broadcasting in admin-tools is desired.

<@1493317298151489577>